### PR TITLE
fix: fail linting if differences are present

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Generate
         run: |
           go generate ./...
-          git status -s
+          git diff --quiet
   terraform:
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +28,7 @@ jobs:
       - name: Format
         run: |
           terraform fmt -recursive
-          git status -s
+          git diff --quiet
       - name: Validate
         run: |
           terraform validate


### PR DESCRIPTION
Git status does not have a exit code depending on if a diff exists. Use git diff --quiet instead which implies an non zero exit code if diff exists.

Fixes SaaS-1106