### PR TITLE
fix: workaround asynchronous api not reporting unfinished updates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Additional examples can be found [here](https://github.com/syseleven/terraform-p
 - `project` (String) ID of your project. If omitted, the `SYS11DBAAS_PROJECT` environment variable is used.
 - `url` (String) URL of the DBaaS API. If omitted, the `SYS11DBAAS_URL` environment variable is used. Otherwise fallbacks to https://dbaas.apis.syseleven.de
 - `wait_for_creation` (Boolean) Whether to wait for the service to be created. If omitted, the `SYS11DBAAS_WAIT_FOR_CREATION` environment variable is used. Defaults to true
+- `wait_for_update` (Boolean) Whether to wait for the service to be updated. If omitted, the `SYS11DBAAS_WAIT_FOR_UPDATE` environment variable is used. Defaults to true
 
 ## Debug logging
 

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -107,6 +107,7 @@ type DatabaseResource struct {
 	project         types.String
 	organization    types.String
 	waitForCreation types.Bool
+	waitForUpdate   types.Bool
 }
 
 func NewDatabaseResource() resource.Resource {
@@ -138,6 +139,7 @@ func (r *DatabaseResource) Configure(_ context.Context, req resource.ConfigureRe
 	r.organization = providerData.organization
 	r.project = providerData.project
 	r.waitForCreation = providerData.waitForCreation
+	r.waitForUpdate = providerData.waitForUpdate
 }
 
 // Read resource information.
@@ -479,14 +481,33 @@ func (r *DatabaseResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	// Update psql
-	response, err := r.client.GetPostgreSQL(ctx, r.organization.ValueString(), r.project.ValueString(), plan.Uuid.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading updated database",
-			"Could not read updated database, unexpected error: "+err.Error(),
-		)
-		return
+	response := database.PostgreSQLGetResponseV1{Status: database.StateNotReady}
+	if r.waitForUpdate.ValueBool() {
+		for response.Status != database.StateReady {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				time.Sleep(30 * time.Second)
+			}
+			response, err = r.client.GetPostgreSQL(ctx, r.organization.ValueString(), r.project.ValueString(), plan.Uuid.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error updating database",
+					"Could not update database, unexpected error: "+err.Error(),
+				)
+				return
+			}
+		}
+	} else {
+		response, err = r.client.GetPostgreSQL(ctx, r.organization.ValueString(), r.project.ValueString(), plan.Uuid.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating database",
+				"Could not update database, unexpected error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	diags = psqlGetResponseToModel(ctx, response, &plan)

--- a/internal/provider/database_resource_v2.go
+++ b/internal/provider/database_resource_v2.go
@@ -147,6 +147,7 @@ type DatabaseResourceV2 struct {
 	project         types.String
 	organization    types.String
 	waitForCreation types.Bool
+	waitForUpdate   types.Bool
 }
 
 func NewDatabaseResourceV2() resource.Resource {
@@ -178,6 +179,7 @@ func (r *DatabaseResourceV2) Configure(_ context.Context, req resource.Configure
 	r.organization = providerData.organization
 	r.project = providerData.project
 	r.waitForCreation = providerData.waitForCreation
+	r.waitForUpdate = providerData.waitForUpdate
 }
 
 // Read resource information.
@@ -620,13 +622,33 @@ func (r *DatabaseResourceV2) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	response, err := r.client.GetPostgreSQL(ctx, r.organization.ValueString(), r.project.ValueString(), plan.Uuid.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading database",
-			"Could not read database : "+plan.Uuid.ValueString()+": "+err.Error(),
-		)
-		return
+	response := database.PostgreSQLGetResponse{Status: database.StateNotReady}
+	if r.waitForUpdate.ValueBool() {
+		for response.Status != database.StateReady {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				time.Sleep(30 * time.Second)
+			}
+			response, err = r.client.GetPostgreSQL(ctx, r.organization.ValueString(), r.project.ValueString(), plan.Uuid.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error updating database",
+					"Could not update database, unexpected error: "+err.Error(),
+				)
+				return
+			}
+		}
+	} else {
+		response, err = r.client.GetPostgreSQL(ctx, r.organization.ValueString(), r.project.ValueString(), plan.Uuid.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating database",
+				"Could not update database, unexpected error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	diags = psqlGetResponseToModelV2(ctx, response, &plan)

--- a/internal/provider/sys11dbaas_provider.go
+++ b/internal/provider/sys11dbaas_provider.go
@@ -37,6 +37,7 @@ type Sys11DBaaSProviderModel struct {
 	Project         types.String `tfsdk:"project"`
 	Organization    types.String `tfsdk:"organization"`
 	WaitForCreation types.Bool   `tfsdk:"wait_for_creation"`
+	WaitForUpdate   types.Bool   `tfsdk:"wait_for_update"`
 }
 
 type sys11DBaaSProviderData struct {
@@ -44,6 +45,7 @@ type sys11DBaaSProviderData struct {
 	project         types.String `tfsdk:"project"`
 	organization    types.String `tfsdk:"organization"`
 	waitForCreation types.Bool   `tfsdk:"wait_for_creation"`
+	waitForUpdate   types.Bool   `tfsdk:"wait_for_update"`
 }
 
 func (p *Sys11DBaaSProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -79,6 +81,11 @@ func (p *Sys11DBaaSProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 				Required:    false,
 				Optional:    true,
 				Description: "Whether to wait for the service to be created. If omitted, the `SYS11DBAAS_WAIT_FOR_CREATION` environment variable is used. Defaults to true",
+			},
+			"wait_for_update": schema.BoolAttribute{
+				Required:    false,
+				Optional:    true,
+				Description: "Whether to wait for the service to be updated. If omitted, the `SYS11DBAAS_WAIT_FOR_UPDATE` environment variable is used. Defaults to true",
 			},
 		},
 	}
@@ -177,6 +184,14 @@ func (p *Sys11DBaaSProvider) Configure(ctx context.Context, req provider.Configu
 		waitForCreation = config.WaitForCreation.ValueBool()
 	}
 
+	waitForUpdate := true
+	if waitForCreationEnv, set := os.LookupEnv("SYS11DBAAS_WAIT_FOR_UPDATE"); !set {
+		waitForUpdate, _ = strconv.ParseBool(waitForCreationEnv)
+	}
+	if !config.WaitForCreation.IsNull() {
+		waitForUpdate = config.WaitForCreation.ValueBool()
+	}
+
 	// If any of the expected configurations are missing, return
 	// errors with provider-specific guidance.
 
@@ -254,12 +269,14 @@ func (p *Sys11DBaaSProvider) Configure(ctx context.Context, req provider.Configu
 		project:         types.StringValue(project),
 		organization:    types.StringValue(organization),
 		waitForCreation: types.BoolValue(waitForCreation),
+		waitForUpdate:   types.BoolValue(waitForUpdate),
 	}
 	resp.ResourceData = &sys11DBaaSProviderData{
 		client:          client,
 		project:         types.StringValue(project),
 		organization:    types.StringValue(organization),
 		waitForCreation: types.BoolValue(waitForCreation),
+		waitForUpdate:   types.BoolValue(waitForUpdate),
 	}
 
 	tflog.Info(ctx, "Configured Sys11DBaaS client", map[string]any{"success": true})


### PR DESCRIPTION
Under some circumstances the api does not reflect the changes of an update request if the read operation is to close (timeley) after the initital update request. This could lead to outdated responses, which get verified against the plan and reports unchanged values. A quick workaround is giving the api some time to apply small changes.

Fixes SaaS-1107