### PR TITLE
feat: do not auto update renovate pull requests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "config:recommended",
     ":docker",
     ":prHourlyLimitNone",
-    ":rebaseStalePrs",
     ":label(renovate)"
   ]
 }


### PR DESCRIPTION
Renovate should not auto update pull requests in order to avoid running to much acceptance tests. It's totally allright for a developer wanting to merge a request from renovate to request a manual rebase or even do it themselves.