### PR TITLE
fix: make datasource tests robust against changes

### DIFF
--- a/internal/provider/postgresql_flavors_data_source_test.go
+++ b/internal/provider/postgresql_flavors_data_source_test.go
@@ -15,7 +15,7 @@ func TestPostgresqlFlavorsDataSource(t *testing.T) {
 				Config: providerConfig + `data "sys11dbaas_postgresql_flavors" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify number of flavors returned
-					resource.TestCheckResourceAttr("data.sys11dbaas_postgresql_flavors.test", "flavors.#", "7"),
+					resource.TestCheckResourceAttrSet("data.sys11dbaas_postgresql_flavors.test", "flavors.0.%"),
 
 					// Verify the first flavor to ensure all attributes are set
 					resource.TestCheckResourceAttr("data.sys11dbaas_postgresql_flavors.test", "flavors.0.id", "SCS-2V-4-50n"),

--- a/internal/provider/postgresql_regions_data_source_test.go
+++ b/internal/provider/postgresql_regions_data_source_test.go
@@ -15,7 +15,7 @@ func TestPostgresqlRegionsDataSource(t *testing.T) {
 				Config: providerConfig + `data "sys11dbaas_postgresql_regions" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify number of regions returned
-					resource.TestCheckResourceAttr("data.sys11dbaas_postgresql_regions.test", "regions.#", "2"),
+					resource.TestCheckResourceAttrSet("data.sys11dbaas_postgresql_regions.test", "regions.0.%"),
 
 					// Verify the first region to ensure all attributes are set
 					resource.TestCheckResourceAttr("data.sys11dbaas_postgresql_regions.test", "regions.0.id", "dus2"),

--- a/internal/provider/postgresql_versions_data_source_test.go
+++ b/internal/provider/postgresql_versions_data_source_test.go
@@ -15,7 +15,7 @@ func TestPostgresqlVersionsDataSource(t *testing.T) {
 				Config: providerConfig + `data "sys11dbaas_postgresql_versions" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify number of versions returned
-					resource.TestCheckResourceAttr("data.sys11dbaas_postgresql_versions.test", "versions.#", "31"),
+					resource.TestCheckResourceAttrSet("data.sys11dbaas_postgresql_versions.test", "versions.0.%"),
 
 					// Verify the first version to ensure all attributes are set
 					resource.TestCheckResourceAttr("data.sys11dbaas_postgresql_versions.test", "versions.0.id", "15.6"),


### PR DESCRIPTION
The tests should not rely on a fixed amount of flavors,regions or versions being available.